### PR TITLE
⚡ Bolt: Optimize list filtering in SavedAudiosScreen

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Expensive Computations in Getters
+**Learning:** Found a performance pattern where a list view builder used a getter `_filteredAudios` which re-evaluated O(N log N) sorting and O(N) string filtering on every `build` (which happens frequently e.g. when selecting an item from the list).
+**Action:** Caching such computations into variables and updating them only when the dependencies change (search query, sort toggle, data itself) significantly reduces main thread blocking. Always look for expensive computations inside getters used directly in `build` methods.

--- a/lib/features/saved_audios/presentation/screens/saved_audios_screen.dart
+++ b/lib/features/saved_audios/presentation/screens/saved_audios_screen.dart
@@ -12,7 +12,6 @@ import '../../../../core/di/service_locator.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../text_to_speech/presentation/widgets/audio_player_widget.dart';
 
-
 class SavedAudiosScreen extends StatefulWidget {
   const SavedAudiosScreen({super.key});
 
@@ -31,14 +30,23 @@ class _SavedAudiosScreenState extends State<SavedAudiosScreen> {
   String _searchQuery = '';
   bool _sortAlphabetical = false;
 
-  List<AudioFile> get _filteredAudios {
-    var list = _audioFiles.where((f) =>
-      f.title.toLowerCase().contains(_searchQuery.toLowerCase())
-    ).toList();
+  // ⚡ Bolt Optimization: Cache filtered and sorted list to prevent
+  // O(N log N) sorting and O(N) string manipulation on every build/re-render.
+  List<AudioFile> _cachedFilteredAudios = [];
+
+  void _updateFilteredAudios() {
+    var list =
+        _audioFiles
+            .where(
+              (f) => f.title.toLowerCase().contains(_searchQuery.toLowerCase()),
+            )
+            .toList();
     if (_sortAlphabetical) {
-      list.sort((a, b) => a.title.toLowerCase().compareTo(b.title.toLowerCase()));
+      list.sort(
+        (a, b) => a.title.toLowerCase().compareTo(b.title.toLowerCase()),
+      );
     }
-    return list;
+    _cachedFilteredAudios = list;
   }
 
   @override
@@ -66,6 +74,7 @@ class _SavedAudiosScreenState extends State<SavedAudiosScreen> {
       if (mounted) {
         setState(() {
           _audioFiles = files;
+          _updateFilteredAudios();
         });
       }
     } catch (e) {
@@ -118,30 +127,33 @@ class _SavedAudiosScreenState extends State<SavedAudiosScreen> {
 
     final newTitle = await showDialog<String>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.savedRenameTitle),
-        content: TextField(
-          controller: controller,
-          autofocus: true,
-          decoration: InputDecoration(hintText: l10n.savedRenameHint),
-          onSubmitted: (value) => Navigator.of(context).pop(value.trim()),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: Text(l10n.genericCancel),
+      builder:
+          (context) => AlertDialog(
+            title: Text(l10n.savedRenameTitle),
+            content: TextField(
+              controller: controller,
+              autofocus: true,
+              decoration: InputDecoration(hintText: l10n.savedRenameHint),
+              onSubmitted: (value) => Navigator.of(context).pop(value.trim()),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: Text(l10n.genericCancel),
+              ),
+              TextButton(
+                onPressed:
+                    () => Navigator.of(context).pop(controller.text.trim()),
+                child: Text(l10n.genericSave),
+              ),
+            ],
           ),
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(controller.text.trim()),
-            child: Text(l10n.genericSave),
-          ),
-        ],
-      ),
     );
 
     controller.dispose();
 
-    if (newTitle == null || newTitle.isEmpty || newTitle == audioFile.title) return;
+    if (newTitle == null || newTitle.isEmpty || newTitle == audioFile.title)
+      return;
 
     final success = await _ttsService.renameAudio(audioFile.id, newTitle);
     if (success) {
@@ -157,6 +169,7 @@ class _SavedAudiosScreenState extends State<SavedAudiosScreen> {
           if (_selectedAudio?.id == audioFile.id) {
             _selectedAudio = _audioFiles[index];
           }
+          _updateFilteredAudios();
         }
       });
       scaffoldMessenger.showSnackBar(
@@ -174,20 +187,21 @@ class _SavedAudiosScreenState extends State<SavedAudiosScreen> {
     final scaffoldMessenger = ScaffoldMessenger.of(context);
     final confirmed = await showDialog<bool>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.savedDeleteConfirmTitle),
-        content: Text(l10n.savedDeleteConfirmMessage(audioFile.title)),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: Text(l10n.genericCancel),
+      builder:
+          (context) => AlertDialog(
+            title: Text(l10n.savedDeleteConfirmTitle),
+            content: Text(l10n.savedDeleteConfirmMessage(audioFile.title)),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: Text(l10n.genericCancel),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: Text(l10n.genericDelete),
+              ),
+            ],
           ),
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            child: Text(l10n.genericDelete),
-          ),
-        ],
-      ),
     );
 
     if (confirmed ?? false) {
@@ -199,6 +213,7 @@ class _SavedAudiosScreenState extends State<SavedAudiosScreen> {
             if (_selectedAudio?.id == audioFile.id) {
               _selectedAudio = null;
             }
+            _updateFilteredAudios();
           });
           scaffoldMessenger.showSnackBar(
             SnackBar(content: Text(l10n.savedDeleted)),
@@ -221,7 +236,7 @@ class _SavedAudiosScreenState extends State<SavedAudiosScreen> {
     final isDarkMode = Provider.of<ThemeProvider>(context).isDarkMode;
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context)!;
-    final displayList = _filteredAudios;
+    final displayList = _cachedFilteredAudios;
 
     return Padding(
       padding: const EdgeInsets.all(16.0),
@@ -231,18 +246,26 @@ class _SavedAudiosScreenState extends State<SavedAudiosScreen> {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Text(
-                l10n.savedTitle,
-                style: theme.textTheme.titleLarge,
-              ),
+              Text(l10n.savedTitle, style: theme.textTheme.titleLarge),
               Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   if (!_isLoading && _audioFiles.isNotEmpty)
                     IconButton(
-                      icon: Icon(_sortAlphabetical ? Icons.sort_by_alpha : Icons.access_time),
-                      tooltip: _sortAlphabetical ? l10n.savedSortByDate : l10n.savedSortByName,
-                      onPressed: () => setState(() => _sortAlphabetical = !_sortAlphabetical),
+                      icon: Icon(
+                        _sortAlphabetical
+                            ? Icons.sort_by_alpha
+                            : Icons.access_time,
+                      ),
+                      tooltip:
+                          _sortAlphabetical
+                              ? l10n.savedSortByDate
+                              : l10n.savedSortByName,
+                      onPressed:
+                          () => setState(() {
+                            _sortAlphabetical = !_sortAlphabetical;
+                            _updateFilteredAudios();
+                          }),
                     ),
                   IconButton(
                     icon: const Icon(Icons.refresh),
@@ -262,23 +285,33 @@ class _SavedAudiosScreenState extends State<SavedAudiosScreen> {
               decoration: InputDecoration(
                 hintText: l10n.savedSearchHint,
                 prefixIcon: const Icon(Icons.search, size: 20),
-                suffixIcon: _searchQuery.isNotEmpty
-                    ? IconButton(
-                        icon: const Icon(Icons.clear, size: 20),
-                        onPressed: () {
-                          _searchController.clear();
-                          setState(() => _searchQuery = '');
-                        },
-                      )
-                    : null,
+                suffixIcon:
+                    _searchQuery.isNotEmpty
+                        ? IconButton(
+                          icon: const Icon(Icons.clear, size: 20),
+                          onPressed: () {
+                            _searchController.clear();
+                            setState(() {
+                              _searchQuery = '';
+                              _updateFilteredAudios();
+                            });
+                          },
+                        )
+                        : null,
                 isDense: true,
                 contentPadding: const EdgeInsets.symmetric(vertical: 10),
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(10),
-                  borderSide: BorderSide(color: isDarkMode ? Colors.grey[700]! : Colors.grey[300]!),
+                  borderSide: BorderSide(
+                    color: isDarkMode ? Colors.grey[700]! : Colors.grey[300]!,
+                  ),
                 ),
               ),
-              onChanged: (v) => setState(() => _searchQuery = v),
+              onChanged:
+                  (v) => setState(() {
+                    _searchQuery = v;
+                    _updateFilteredAudios();
+                  }),
             ),
           ],
 
@@ -288,18 +321,20 @@ class _SavedAudiosScreenState extends State<SavedAudiosScreen> {
             Expanded(
               child: Shimmer.fromColors(
                 baseColor: isDarkMode ? Colors.grey[800]! : Colors.grey[300]!,
-                highlightColor: isDarkMode ? Colors.grey[700]! : Colors.grey[100]!,
+                highlightColor:
+                    isDarkMode ? Colors.grey[700]! : Colors.grey[100]!,
                 child: ListView.builder(
                   physics: const NeverScrollableScrollPhysics(),
                   itemCount: 5,
-                  itemBuilder: (_, __) => Container(
-                    margin: const EdgeInsets.only(bottom: 8),
-                    height: 72,
-                    decoration: BoxDecoration(
-                      color: Colors.white,
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                  ),
+                  itemBuilder:
+                      (_, __) => Container(
+                        margin: const EdgeInsets.only(bottom: 8),
+                        height: 72,
+                        decoration: BoxDecoration(
+                          color: Colors.white,
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
                 ),
               ),
             )
@@ -350,16 +385,23 @@ class _SavedAudiosScreenState extends State<SavedAudiosScreen> {
                           margin: const EdgeInsets.only(bottom: 8),
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(12),
-                            side: isSelected
-                                ? BorderSide(
-                              color: isDarkMode ? darkAccentColor : lightAccentColor,
-                              width: 2,
-                            )
-                                : BorderSide.none,
+                            side:
+                                isSelected
+                                    ? BorderSide(
+                                      color:
+                                          isDarkMode
+                                              ? darkAccentColor
+                                              : lightAccentColor,
+                                      width: 2,
+                                    )
+                                    : BorderSide.none,
                           ),
-                          color: isSelected
-                              ? (isDarkMode ? const Color(0xFF252525) : const Color(0xFFF0F0F0))
-                              : null,
+                          color:
+                              isSelected
+                                  ? (isDarkMode
+                                      ? const Color(0xFF252525)
+                                      : const Color(0xFFF0F0F0))
+                                  : null,
                           child: ListTile(
                             title: Text(
                               audioFile.title,
@@ -370,7 +412,10 @@ class _SavedAudiosScreenState extends State<SavedAudiosScreen> {
                               style: theme.textTheme.bodySmall,
                             ),
                             leading: CircleAvatar(
-                              backgroundColor: isDarkMode ? darkPrimaryColor : lightPrimaryColor,
+                              backgroundColor:
+                                  isDarkMode
+                                      ? darkPrimaryColor
+                                      : lightPrimaryColor,
                               child: const Icon(
                                 Icons.music_note,
                                 color: Colors.white,
@@ -394,18 +439,24 @@ class _SavedAudiosScreenState extends State<SavedAudiosScreen> {
                             onLongPress: () => _copyToClipboard(audioFile),
                             onTap: () async {
                               if (!isSelected) {
-                                final scaffoldMessenger = ScaffoldMessenger.of(context);
-                                final exists = await File(audioFile.filePath).exists();
+                                final scaffoldMessenger = ScaffoldMessenger.of(
+                                  context,
+                                );
+                                final exists =
+                                    await File(audioFile.filePath).exists();
                                 if (!exists) {
                                   scaffoldMessenger.showSnackBar(
-                                    SnackBar(content: Text(l10n.savedFileNotFound)),
+                                    SnackBar(
+                                      content: Text(l10n.savedFileNotFound),
+                                    ),
                                   );
                                   return;
                                 }
                               }
                               if (mounted) {
                                 setState(() {
-                                  _selectedAudio = isSelected ? null : audioFile;
+                                  _selectedAudio =
+                                      isSelected ? null : audioFile;
                                 });
                               }
                             },
@@ -420,7 +471,8 @@ class _SavedAudiosScreenState extends State<SavedAudiosScreen> {
                     Container(
                       padding: const EdgeInsets.all(16),
                       decoration: BoxDecoration(
-                        color: isDarkMode ? const Color(0xFF1E1E1E) : Colors.white,
+                        color:
+                            isDarkMode ? const Color(0xFF1E1E1E) : Colors.white,
                         borderRadius: BorderRadius.circular(12),
                         boxShadow: [
                           BoxShadow(
@@ -445,29 +497,41 @@ class _SavedAudiosScreenState extends State<SavedAudiosScreen> {
                               IconButton(
                                 icon: Icon(
                                   Icons.edit_rounded,
-                                  color: isDarkMode ? darkAccentColor : lightAccentColor,
+                                  color:
+                                      isDarkMode
+                                          ? darkAccentColor
+                                          : lightAccentColor,
                                   size: 20,
                                 ),
                                 tooltip: l10n.savedRename,
-                                onPressed: () => _renameAudioFile(_selectedAudio!),
+                                onPressed:
+                                    () => _renameAudioFile(_selectedAudio!),
                               ),
                               IconButton(
                                 icon: Icon(
                                   Icons.copy_rounded,
-                                  color: isDarkMode ? darkAccentColor : lightAccentColor,
+                                  color:
+                                      isDarkMode
+                                          ? darkAccentColor
+                                          : lightAccentColor,
                                   size: 20,
                                 ),
                                 tooltip: l10n.savedCopied,
-                                onPressed: () => _copyToClipboard(_selectedAudio!),
+                                onPressed:
+                                    () => _copyToClipboard(_selectedAudio!),
                               ),
                               IconButton(
                                 icon: Icon(
                                   Icons.share_rounded,
-                                  color: isDarkMode ? darkAccentColor : lightAccentColor,
+                                  color:
+                                      isDarkMode
+                                          ? darkAccentColor
+                                          : lightAccentColor,
                                   size: 20,
                                 ),
                                 tooltip: l10n.savedShare,
-                                onPressed: () => _shareAudioFile(_selectedAudio!),
+                                onPressed:
+                                    () => _shareAudioFile(_selectedAudio!),
                               ),
                             ],
                           ),


### PR DESCRIPTION
💡 What: Cached the result of filtering and sorting the audio files list into a `_cachedFilteredAudios` list, which is only updated via `_updateFilteredAudios()` when dependencies change (e.g., search query, sort order, or list updates).

🎯 Why: The previous implementation used a getter (`_filteredAudios`) that performed O(N log N) sorting and O(N) string filtering dynamically on every `build` execution. This caused unnecessary overhead, particularly when state changes like selecting an audio file (`_selectedAudio`) triggered a rebuild. 

📊 Impact: Reduces main-thread blocking by preventing redundant list filtering and sorting on UI re-renders, making the selection and general interaction with the `SavedAudiosScreen` list much faster.

🔬 Measurement: Verifiable by monitoring rebuild times and main-thread performance when interacting with items in the saved audios list, particularly with a large number of audio files.

---
*PR created automatically by Jules for task [18347729091571890466](https://jules.google.com/task/18347729091571890466) started by @loda616*