### PR TITLE
🧹 [code health] Extract large build method in SettingsScreen

### DIFF
--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -9,6 +9,10 @@ import '../../../../core/constants/constants.dart';
 import '../../../../core/di/service_locator.dart';
 import '../../../../l10n/app_localizations.dart';
 import 'model_manager_screen.dart';
+import '../widgets/theme_settings_card.dart';
+import '../widgets/voice_settings_card.dart';
+import '../widgets/storage_settings_card.dart';
+import '../widgets/about_card.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -41,7 +45,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
   @override
   Widget build(BuildContext context) {
     final themeProvider = Provider.of<ThemeProvider>(context);
-    final ttsService = Provider.of<TTSService>(context);
     final isDarkMode = themeProvider.isDarkMode;
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context)!;
@@ -59,313 +62,126 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ),
             const SizedBox(height: 24),
 
-            // Theme Settings
-            Card(
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      l10n.settingsAppearance,
-                      style: theme.textTheme.titleMedium,
-                    ),
-                    const SizedBox(height: 16),
-                    SwitchListTile(
-                      title: Text(
-                        l10n.settingsDarkMode,
-                        style: theme.textTheme.bodyLarge,
-                      ),
-                      subtitle: Text(
-                        isDarkMode ? l10n.settingsDarkTheme : l10n.settingsLightTheme,
-                        style: theme.textTheme.bodySmall,
-                      ),
-                      value: isDarkMode,
-                      onChanged: (_) {
-                        themeProvider.toggleTheme();
-                      },
-                      secondary: Icon(
-                        isDarkMode ? Icons.dark_mode : Icons.light_mode,
-                        color: isDarkMode ? theme.colorScheme.secondary : theme.colorScheme.primary,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
+            const ThemeSettingsCard(),
             const SizedBox(height: 16),
 
-            // Voice/TTS Settings
-            Card(
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(l10n.settingsVoice, style: theme.textTheme.titleMedium),
-                    const SizedBox(height: 8),
-                    ListTile(
-                      contentPadding: EdgeInsets.zero,
-                      title: Text(l10n.settingsDefaultSpeed, style: theme.textTheme.bodyLarge),
-                      subtitle: Text('${_defaultSpeed.toStringAsFixed(1)}x'),
-                      trailing: SizedBox(
-                        width: 150,
-                        child: Slider(
-                          value: _defaultSpeed,
-                          min: AppConstants.minSpeed,
-                          max: AppConstants.maxSpeed,
-                          divisions: 25,
-                          label: '${_defaultSpeed.toStringAsFixed(1)}x',
-                          onChanged: (v) async {
-                            setState(() => _defaultSpeed = v);
-                            final prefs = await SharedPreferences.getInstance();
-                            await prefs.setDouble(AppConstants.storageKeyDefaultSpeed, v);
-                          },
-                        ),
-                      ),
-                    ),
-                    ListTile(
-                      contentPadding: EdgeInsets.zero,
-                      title: Text(l10n.settingsTtsEngine),
-                      subtitle: Text('${ttsService.activeModel.name} (${ttsService.activeModel.language})'),
-                      trailing: const Icon(Icons.offline_bolt, color: Colors.green),
-                    ),
-                    ListTile(
-                      contentPadding: EdgeInsets.zero,
-                      title: Text(l10n.settingsDiscoverVoices),
-                      subtitle: Text(l10n.settingsDiscoverVoicesDesc),
-                      trailing: const Icon(Icons.language, color: Colors.blue),
-                      onTap: () {
-                        Navigator.of(context).push(
-                          PageRouteBuilder(
-                            pageBuilder: (_, __, ___) => const ModelManagerScreen(),
-                            transitionsBuilder: (_, animation, __, child) {
-                              return SlideTransition(
-                                position: Tween<Offset>(
-                                  begin: const Offset(1.0, 0.0),
-                                  end: Offset.zero,
-                                ).animate(CurvedAnimation(
-                                  parent: animation,
-                                  curve: Curves.easeOutCubic,
-                                )),
-                                child: child,
-                              );
-                            },
-                            transitionDuration: const Duration(milliseconds: 300),
-                          ),
-                        );
-                      },
-                    ),
-                  ],
-                ),
-              ),
+            VoiceSettingsCard(
+              defaultSpeed: _defaultSpeed,
+              onSpeedChanged: (v) async {
+                setState(() => _defaultSpeed = v);
+                final prefs = await SharedPreferences.getInstance();
+                await prefs.setDouble(AppConstants.storageKeyDefaultSpeed, v);
+              },
+              onDiscoverVoices: () {
+                Navigator.of(context).push(
+                  PageRouteBuilder(
+                    pageBuilder: (_, __, ___) => const ModelManagerScreen(),
+                    transitionsBuilder: (_, animation, __, child) {
+                      return SlideTransition(
+                        position: Tween<Offset>(
+                          begin: const Offset(1.0, 0.0),
+                          end: Offset.zero,
+                        ).animate(CurvedAnimation(
+                          parent: animation,
+                          curve: Curves.easeOutCubic,
+                        )),
+                        child: child,
+                      );
+                    },
+                    transitionDuration: const Duration(milliseconds: 300),
+                  ),
+                );
+              },
             ),
 
             const SizedBox(height: 16),
 
-            // Storage Settings
-            Card(
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      l10n.settingsStorage,
-                      style: theme.textTheme.titleMedium,
+            StorageSettingsCard(
+              isClearing: _isClearing,
+              isExporting: _isExporting,
+              onClearAll: () async {
+                final confirmed = await showDialog<bool>(
+                  context: context,
+                  builder: (context) => AlertDialog(
+                    title: Text(l10n.settingsClearConfirmTitle),
+                    content: Text(
+                      l10n.settingsClearConfirmMessage,
                     ),
-                    const SizedBox(height: 16),
-                    ListTile(
-                      title: Text(
-                        l10n.settingsClearAll,
-                        style: theme.textTheme.bodyLarge,
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.of(context).pop(false),
+                        child: Text(l10n.genericCancel),
                       ),
-                      subtitle: Text(
-                        l10n.settingsClearAllDesc,
+                      TextButton(
+                        onPressed: () => Navigator.of(context).pop(true),
+                        child: Text(l10n.genericDeleteAll),
                       ),
-                      trailing: _isClearing
-                          ? const SizedBox(
-                        width: 20,
-                        height: 20,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                        ),
-                      )
-                          : const Icon(Icons.delete_forever),
-                      onTap: _isClearing
-                          ? null
-                          : () async {
-                        final confirmed = await showDialog<bool>(
-                          context: context,
-                          builder: (context) => AlertDialog(
-                            title: Text(l10n.settingsClearConfirmTitle),
-                            content: Text(
-                              l10n.settingsClearConfirmMessage,
-                            ),
-                            actions: [
-                              TextButton(
-                                onPressed: () => Navigator.of(context).pop(false),
-                                child: Text(l10n.genericCancel),
-                              ),
-                              TextButton(
-                                onPressed: () => Navigator.of(context).pop(true),
-                                child: Text(l10n.genericDeleteAll),
-                              ),
-                            ],
-                          ),
-                        );
+                    ],
+                  ),
+                );
 
-                        if (confirmed ?? false) {
-                          setState(() {
-                            _isClearing = true;
-                          });
+                if (confirmed ?? false) {
+                  setState(() {
+                    _isClearing = true;
+                  });
 
-                          try {
-                            await _ttsService.clearAllSavedAudios();
-                            if (!context.mounted) return;
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(
-                                content: Text(l10n.settingsClearSuccess),
-                              ),
-                            );
-                          } catch (e) {
-                            if (!context.mounted) return;
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(
-                                content: Text(l10n.genericErrorPrefix(e.toString())),
-                              ),
-                            );
-                          } finally {
-                            setState(() {
-                              _isClearing = false;
-                            });
-                          }
-                        }
-                      },
+                  try {
+                    await _ttsService.clearAllSavedAudios();
+                    if (!context.mounted) return;
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text(l10n.settingsClearSuccess),
+                      ),
+                    );
+                  } catch (e) {
+                    if (!context.mounted) return;
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text(l10n.genericErrorPrefix(e.toString())),
+                      ),
+                    );
+                  } finally {
+                    setState(() {
+                      _isClearing = false;
+                    });
+                  }
+                }
+              },
+              onExportAll: () async {
+                setState(() {
+                  _isExporting = true;
+                });
+
+                try {
+                  final exportPath = await _ttsService.exportAllAudios();
+                  if (!context.mounted) return;
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(l10n.settingsExportSuccess(exportPath)),
+                      duration: const Duration(seconds: 5),
                     ),
-
-                    ListTile(
-                      title: Text(
-                        l10n.settingsExportAll,
-                        style: theme.textTheme.bodyLarge,
-                      ),
-                      subtitle: Text(
-                        l10n.settingsExportAllDesc,
-                      ),
-                      trailing: _isExporting
-                          ? const SizedBox(
-                        width: 20,
-                        height: 20,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                        ),
-                      )
-                          : const Icon(Icons.file_download),
-                      onTap: _isExporting
-                          ? null
-                          : () async {
-                        setState(() {
-                          _isExporting = true;
-                        });
-
-                        try {
-                          final exportPath = await _ttsService.exportAllAudios();
-                          if (!context.mounted) return;
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(
-                              content: Text(l10n.settingsExportSuccess(exportPath)),
-                              duration: const Duration(seconds: 5),
-                            ),
-                          );
-                        } catch (e) {
-                          if (!context.mounted) return;
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(
-                              content: Text(l10n.genericErrorPrefix(e.toString())),
-                            ),
-                          );
-                        } finally {
-                          setState(() {
-                            _isExporting = false;
-                          });
-                        }
-                      },
+                  );
+                } catch (e) {
+                  if (!context.mounted) return;
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(l10n.genericErrorPrefix(e.toString())),
                     ),
-                  ],
-                ),
-              ),
+                  );
+                } finally {
+                  setState(() {
+                    _isExporting = false;
+                  });
+                }
+              },
             ),
 
             const SizedBox(height: 16),
 
-            // About section
-            Card(
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      l10n.settingsAbout,
-                      style: theme.textTheme.titleMedium,
-                    ),
-                    const SizedBox(height: 16),
-                    ListTile(
-                      title: Text('Sonify', style: theme.textTheme.bodyLarge),
-                      subtitle: Text('v${AppConstants.appVersion} — Powered by ${AppConstants.engineVersion}'),
-                      trailing: const Icon(Icons.info_outline),
-                      onTap: () {
-                        showAboutDialog(
-                          context: context,
-                          applicationName: AppConstants.appName,
-                          applicationVersion: AppConstants.appVersion,
-                          applicationLegalese: '© 2026 Khalid',
-                          applicationIcon: ClipRRect(
-                            borderRadius: BorderRadius.circular(12),
-                            child: Image.asset(
-                              'assets/images/sonify-logo.png',
-                              width: 48,
-                              height: 48,
-                              errorBuilder: (_, __, ___) => Icon(
-                                Icons.record_voice_over,
-                                color: isDarkMode ? darkAccentColor : lightPrimaryColor,
-                                size: 36,
-                              ),
-                            ),
-                          ),
-                          children: [
-                            const SizedBox(height: 16),
-                            Text(
-                              l10n.settingsAboutDescription,
-                            ),
-                            const SizedBox(height: 12),
-                            Text(
-                              l10n.settingsAboutTechInfo,
-                              style: const TextStyle(fontSize: 12, color: Colors.grey),
-                            ),
-                          ],
-                        );
-                      },
-                    ),
-                  ],
-                ),
-              ),
-            ),
+            AboutCard(isDarkMode: isDarkMode),
           ],
         ),
       ),
     );
   }
-}
+}

--- a/lib/features/settings/presentation/widgets/about_card.dart
+++ b/lib/features/settings/presentation/widgets/about_card.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import '../../../../core/constants/constants.dart';
+import '../../../../core/themes/theme_config.dart';
+import '../../../../l10n/app_localizations.dart';
+
+class AboutCard extends StatelessWidget {
+  final bool isDarkMode;
+
+  const AboutCard({
+    super.key,
+    required this.isDarkMode,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
+
+    return Card(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l10n.settingsAbout,
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 16),
+            ListTile(
+              title: Text('Sonify', style: theme.textTheme.bodyLarge),
+              subtitle: Text('v${AppConstants.appVersion} — Powered by ${AppConstants.engineVersion}'),
+              trailing: const Icon(Icons.info_outline),
+              onTap: () {
+                showAboutDialog(
+                  context: context,
+                  applicationName: AppConstants.appName,
+                  applicationVersion: AppConstants.appVersion,
+                  applicationLegalese: '© 2026 Khalid',
+                  applicationIcon: ClipRRect(
+                    borderRadius: BorderRadius.circular(12),
+                    child: Image.asset(
+                      'assets/images/sonify-logo.png',
+                      width: 48,
+                      height: 48,
+                      errorBuilder: (_, __, ___) => Icon(
+                        Icons.record_voice_over,
+                        color: isDarkMode ? darkAccentColor : lightPrimaryColor,
+                        size: 36,
+                      ),
+                    ),
+                  ),
+                  children: [
+                    const SizedBox(height: 16),
+                    Text(
+                      l10n.settingsAboutDescription,
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      l10n.settingsAboutTechInfo,
+                      style: const TextStyle(fontSize: 12, color: Colors.grey),
+                    ),
+                  ],
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/presentation/widgets/storage_settings_card.dart
+++ b/lib/features/settings/presentation/widgets/storage_settings_card.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import '../../../../l10n/app_localizations.dart';
+
+class StorageSettingsCard extends StatelessWidget {
+  final bool isClearing;
+  final bool isExporting;
+  final VoidCallback onClearAll;
+  final VoidCallback onExportAll;
+
+  const StorageSettingsCard({
+    super.key,
+    required this.isClearing,
+    required this.isExporting,
+    required this.onClearAll,
+    required this.onExportAll,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
+
+    return Card(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l10n.settingsStorage,
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 16),
+            ListTile(
+              title: Text(
+                l10n.settingsClearAll,
+                style: theme.textTheme.bodyLarge,
+              ),
+              subtitle: Text(
+                l10n.settingsClearAllDesc,
+              ),
+              trailing: isClearing
+                  ? const SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                ),
+              )
+                  : const Icon(Icons.delete_forever),
+              onTap: isClearing ? null : onClearAll,
+            ),
+
+            ListTile(
+              title: Text(
+                l10n.settingsExportAll,
+                style: theme.textTheme.bodyLarge,
+              ),
+              subtitle: Text(
+                l10n.settingsExportAllDesc,
+              ),
+              trailing: isExporting
+                  ? const SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                ),
+              )
+                  : const Icon(Icons.file_download),
+              onTap: isExporting ? null : onExportAll,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/presentation/widgets/theme_settings_card.dart
+++ b/lib/features/settings/presentation/widgets/theme_settings_card.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../theme/presentation/providers/theme_provider.dart';
+import '../../../../l10n/app_localizations.dart';
+
+class ThemeSettingsCard extends StatelessWidget {
+  const ThemeSettingsCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final themeProvider = Provider.of<ThemeProvider>(context);
+    final isDarkMode = themeProvider.isDarkMode;
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
+
+    return Card(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l10n.settingsAppearance,
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 16),
+            SwitchListTile(
+              title: Text(
+                l10n.settingsDarkMode,
+                style: theme.textTheme.bodyLarge,
+              ),
+              subtitle: Text(
+                isDarkMode ? l10n.settingsDarkTheme : l10n.settingsLightTheme,
+                style: theme.textTheme.bodySmall,
+              ),
+              value: isDarkMode,
+              onChanged: (_) {
+                themeProvider.toggleTheme();
+              },
+              secondary: Icon(
+                isDarkMode ? Icons.dark_mode : Icons.light_mode,
+                color: isDarkMode ? theme.colorScheme.secondary : theme.colorScheme.primary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/presentation/widgets/voice_settings_card.dart
+++ b/lib/features/settings/presentation/widgets/voice_settings_card.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../../core/constants/constants.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../../../services/tts_service.dart';
+
+class VoiceSettingsCard extends StatelessWidget {
+  final double defaultSpeed;
+  final ValueChanged<double> onSpeedChanged;
+  final VoidCallback onDiscoverVoices;
+
+  const VoiceSettingsCard({
+    super.key,
+    required this.defaultSpeed,
+    required this.onSpeedChanged,
+    required this.onDiscoverVoices,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final ttsService = Provider.of<TTSService>(context);
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
+
+    return Card(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(l10n.settingsVoice, style: theme.textTheme.titleMedium),
+            const SizedBox(height: 8),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              title: Text(l10n.settingsDefaultSpeed, style: theme.textTheme.bodyLarge),
+              subtitle: Text('${defaultSpeed.toStringAsFixed(1)}x'),
+              trailing: SizedBox(
+                width: 150,
+                child: Slider(
+                  value: defaultSpeed,
+                  min: AppConstants.minSpeed,
+                  max: AppConstants.maxSpeed,
+                  divisions: 25,
+                  label: '${defaultSpeed.toStringAsFixed(1)}x',
+                  onChanged: onSpeedChanged,
+                ),
+              ),
+            ),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              title: Text(l10n.settingsTtsEngine),
+              subtitle: Text('${ttsService.activeModel.name} (${ttsService.activeModel.language})'),
+              trailing: const Icon(Icons.offline_bolt, color: Colors.green),
+            ),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              title: Text(l10n.settingsDiscoverVoices),
+              subtitle: Text(l10n.settingsDiscoverVoicesDesc),
+              trailing: const Icon(Icons.language, color: Colors.blue),
+              onTap: onDiscoverVoices,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
🎯 **What:** Extracted 'Theme Settings', 'Voice Settings', 'Storage Settings', and 'About' cards from `SettingsScreen` into separate widget classes: `ThemeSettingsCard`, `VoiceSettingsCard`, `StorageSettingsCard`, and `AboutCard`.
💡 **Why:** This drastically reduces the size and complexity of the `SettingsScreen` build method, improving maintainability and readability of the codebase.
✅ **Verification:** Verified code structure and syntax with a custom non-truncating read tool and `dart analyze`. Received positive code review confirming that all functionality and state management are preserved.
✨ **Result:** The `SettingsScreen` build method has been reduced from approximately 300 lines to around 100 lines, making it significantly easier to maintain.

---
*PR created automatically by Jules for task [12593690464135236849](https://jules.google.com/task/12593690464135236849) started by @loda616*