### PR TITLE
🧹 [Code Health] Use ThemeData for BottomNavigationBar

### DIFF
--- a/lib/app/home_screen.dart
+++ b/lib/app/home_screen.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:sonify/features/saved_audios/presentation/screens/saved_audios_screen.dart';
 import 'package:sonify/features/settings/presentation/screens/settings_screen.dart';
 import 'package:sonify/features/text_to_speech/presentation/screens/text_to_speech_screen.dart';
 import 'package:sonify/l10n/app_localizations.dart';
 
-import '../features/theme/presentation/providers/theme_provider.dart';
 import '../core/widgets/theme_switch_widget.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -26,9 +24,6 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final themeProvider = Provider.of<ThemeProvider>(context);
-    final isDarkMode = themeProvider.isDarkMode;
-    final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context)!;
 
     return Scaffold(
@@ -52,9 +47,6 @@ class _HomeScreenState extends State<HomeScreen> {
             _selectedIndex = index;
           });
         },
-        backgroundColor: isDarkMode ? const Color(0xFF1E1E1E) : Colors.white,
-        selectedItemColor: isDarkMode ? theme.colorScheme.secondary : theme.colorScheme.primary,
-        unselectedItemColor: isDarkMode ? const Color(0xFF8E8E8E) : Colors.grey,
         items: [
           BottomNavigationBarItem(
             icon: const Icon(Icons.record_voice_over),

--- a/lib/core/themes/theme_config.dart
+++ b/lib/core/themes/theme_config.dart
@@ -67,6 +67,11 @@ ThemeData getLightTheme() {
         borderSide: const BorderSide(color: lightAccentColor, width: 2),
       ),
     ),
+    bottomNavigationBarTheme: const BottomNavigationBarThemeData(
+      backgroundColor: Colors.white,
+      selectedItemColor: lightPrimaryColor,
+      unselectedItemColor: Colors.grey,
+    ),
   );
 }
 
@@ -126,6 +131,11 @@ ThemeData getDarkTheme() {
         borderSide: const BorderSide(color: darkAccentColor, width: 2),
       ),
       hintStyle: const TextStyle(color: Color(0xFF8E8E8E)),
+    ),
+    bottomNavigationBarTheme: const BottomNavigationBarThemeData(
+      backgroundColor: Color(0xFF1E1E1E),
+      selectedItemColor: darkAccentColor,
+      unselectedItemColor: Color(0xFF8E8E8E),
     ),
   );
 }


### PR DESCRIPTION
🎯 **What:** Removed hardcoded color values (`backgroundColor`, `selectedItemColor`, `unselectedItemColor`) from `HomeScreen`'s `BottomNavigationBar`. Moved these definitions to `BottomNavigationBarThemeData` in `theme_config.dart`.
💡 **Why:** Centralizes the app's color definitions, eliminates conditional dark mode checks inside UI components, and improves maintainability by adhering strictly to the material theme setup.
✅ **Verification:** Verified `flutter analyze` passes, code compiles, and `theme_config.dart` includes proper light and dark mappings.
✨ **Result:** A cleaner, simpler `HomeScreen` widget tree and robust theme centralization!

---
*PR created automatically by Jules for task [17145779503862801344](https://jules.google.com/task/17145779503862801344) started by @loda616*